### PR TITLE
Fix audio element having 0 width

### DIFF
--- a/src/css/site.css
+++ b/src/css/site.css
@@ -121,7 +121,7 @@ a.imgLink img.ss-spoiler-border {
 }
 
 /* Inline Expanded, not Hover */
-:root.fit-images :not(ruffle-player).imgExpanded {
+:root.fit-images :not(ruffle-player,audio).imgExpanded {
     max-height: 90vh !important;
     object-fit: contain;
     width: auto !important;


### PR DESCRIPTION
Do not apply `.fit-images` styles to audio tags.

At least in brave, applying  `width: auto !important` makes an audio element have a width of 0, hiding it.

<img width="562" height="162" alt="audio" src="https://github.com/user-attachments/assets/b0d52371-6d56-4fd5-a241-2931d4b470da" />

Post from the screenshot: https://8chan.moe/vyt/last/1619552.html#1620048